### PR TITLE
Version bump 0.3.0

### DIFF
--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: ${KEG_DOCKER_FILE}
       args:
         - DOC_APP_PATH
-        - DOC_APP_PORT
+        - KEG_PROXY_PORT
         - DOC_CORE_PATH
         - DOC_COMPONENTS_PATH
         - DOC_RESOLVER_PATH
@@ -24,7 +24,7 @@ services:
     container_name: ${CONTAINER_NAME}
     environment:
       - DOC_APP_PATH
-      - DOC_APP_PORT
+      - KEG_PROXY_PORT
       - ENV
       - KEG_EXEC_CMD
       - KEG_DOCKER_EXEC
@@ -37,6 +37,3 @@ services:
       - DOC_JSUTILS_PAT
       - DOC_EVF_PATH
       - NODE_ENV
-    ports:
-      - 80:${DOC_APP_PORT}
-      - ${DOC_APP_PORT}:${DOC_APP_PORT}

--- a/container/values.yml
+++ b/container/values.yml
@@ -30,7 +30,7 @@ env:
   DOC_JSUTILS_PATH: /keg/app/node_modules/@keg-hub/jsutils
 
   # Default port of the app to expose from the container
-  DOC_APP_PORT: 3000
+  KEG_PROXY_PORT: 3000
 
 
   # --- GENERAL CONTEXT ENVs --- #

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@keg-hub/tap-evf-sessions": "1.2.2",
+    "@keg-hub/tap-evf-sessions": "1.3.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,10 +1424,10 @@
   resolved "https://registry.yarnpkg.com/@keg-hub/jsutils/-/jsutils-6.2.1.tgz#0d9dbf562e313eb7690d36a2b8e9147b1e08d52a"
   integrity sha512-aCZ86nB+f6awWbDIPd6VPaePQjm8AYNXvGrwe2Ip06F6oVJZ7tiOIBwFHeK/gAKqmw1wnxl4B0z21vQeINd6dw==
 
-"@keg-hub/tap-evf-sessions@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@keg-hub/tap-evf-sessions/-/tap-evf-sessions-1.2.2.tgz#4753a085dcbdbc47104ea6799c53ab53ff368c59"
-  integrity sha512-C5E5DGcN70js6m57p5vImWOZ/uPdLa5FiZdtHvd1Ej7X6Uf8Xo1J9KEHcKK+fwBH/yl76vz5R3t2GD49G9b/ZQ==
+"@keg-hub/tap-evf-sessions@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@keg-hub/tap-evf-sessions/-/tap-evf-sessions-1.3.0.tgz#e0c32a9ba303256fe9f586590d84d65b73babf54"
+  integrity sha512-vRX5S8TNbBrlM2rB0hcA348/zb89W14qWP/oh2Lt4KyhKrKDeD4lR9kvxnLiLx+2L1xYW9dMIsw7wAiTJrWK/g==
   dependencies:
     "@keg-hub/jsutils" "6.2.1"
     axios "0.19.2"


### PR DESCRIPTION
sessions component bump to 1.3.0

updated the docker and values file so it works with new fresh keg proxy