### PR TITLE
Zen 385 remove deps

### DIFF
--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -75,6 +75,11 @@ actions:
       detach: true
       cmds:
         - yarn dev
+    run:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      cmds:
+        - yarn dev
     att:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
       privileged: true
@@ -95,6 +100,11 @@ actions:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
       privileged: true
       detach: true
+      cmds:
+        - yarn dev
+    run:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
       cmds:
         - yarn dev
     att:

--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -49,15 +49,21 @@ actions:
         - bash
   jsutils:
     install:
-      location: /keg/app/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
       privileged: true
       cmds:
         - yarn install
     start:
-      location: /keg/app/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
       privileged: true
       cmds:
         - yarn dev
+    copy:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      privileged: true
+      cmds:
+        - rm -rf /keg/app/node_modules/@keg-hub/jsutils/build
+        - cp -R /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils/build /keg/app/node_modules/@keg-hub/jsutils/build
   retheme:
     install:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme

--- a/container/run.sh
+++ b/container/run.sh
@@ -34,7 +34,10 @@ keg_run_the_app(){
 
   cd $APP_PATH
 
-  KEG_EXEC_CMD="start"
+  if [[ -z "$KEG_EXEC_CMD" ]]; then
+    KEG_EXEC_CMD="start"
+  fi
+
   keg_message "Running command 'yarn $KEG_EXEC_CMD'"
   yarn $KEG_EXEC_CMD
 }

--- a/container/values.yml
+++ b/container/values.yml
@@ -46,3 +46,4 @@ env:
   # where to place the build output
   KEG_CONSUMER_BUILD_PATH: /keg/app/node_modules/@keg-hub/tap-evf-sessions
   KEG_FROM_BASE: false
+  KEG_EXEC_CMD: start

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,9 +1,10 @@
 env:
 
   # --- LOCAL ENV CONTEXT --- #
-  CORE_PATH: "{{ cli.taps.links.core }}"
+  CORE_PATH: "{{ cli.paths.core }}"
   COMPONENTS_PATH: "{{ cli.paths.components }}"
   RETHEME_PATH: "{{ cli.taps.links.retheme }}"
+  JSUTILS_PATH: "{{ cli.paths.jsutils }}"
 
   # --- KEG-CLI ENV CONTEXT --- #
 
@@ -32,7 +33,7 @@ env:
   DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
   DOC_RETHEME_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
   DOC_RESOLVER_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
-  DOC_JSUTILS_PATH: /keg/app/node_modules/@keg-hub/jsutils
+  DOC_JSUTILS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
 
   # Default port of the app to expose from the container
   KEG_PROXY_PORT: 3000

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,5 +1,10 @@
 env:
 
+  # --- LOCAL ENV CONTEXT --- #
+  CORE_PATH: "{{ cli.taps.links.core }}"
+  COMPONENTS_PATH: "{{ cli.paths.components }}"
+  RETHEME_PATH: "{{ cli.taps.links.retheme }}"
+
   # --- KEG-CLI ENV CONTEXT --- #
 
   # Set the paths to the linked external app


### PR DESCRIPTION
**Ticket**:
* [ZEN-384](https://jira.simpleviewtools.com/browse/ZEN-384)
* [ZEN-385](https://jira.simpleviewtools.com/browse/ZEN-385)

> **IMPORTANT**
> This PR should be tested alongside these PRs
> [Keg-Hub](https://github.com/simpleviewinc/keg-hub/pull/69)
> [Tap-Events-Force](https://github.com/simpleviewinc/tap-events-force/pull/87)

## Context
* Currently, component prop-types are being included in the production bundle
* They don't need to be since they aren't going to be used in production

## Goal

* Clean up the keg-components exports
* Remove prop-types from the keg-components export

## Updates

* `container/mutagen.yml`
  * Added more sync actions
* `container/run.sh`
  * added a default if env `KEG_EXEC_CMD` is not set, but allows it to be overridden
* `container/values.yml`
  * Added some paths 

## Testing

* Run all the tests from [this PR](https://github.com/simpleviewinc/tap-events-force/pull/87) to test these changes

