### PR TITLE
ZEN-463: image from container updates

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,9 +8,11 @@ ARG KEG_COPY_LOCAL
 # Add a FROM for the tap-base image to we can copy content from it
 ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
 FROM $KEG_BASE_IMAGE as tap-base
-
 ARG DOC_APP_PATH=/keg/tap
 ENV DOC_APP_PATH=$DOC_APP_PATH
+
+# link repo to provider
+LABEL org.opencontainers.image.source $GIT_APP_URL
 
 # Set the current directory to tap repo
 WORKDIR $DOC_APP_PATH

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,5 @@
 # Path of the tap within the docker container
-ARG DOC_APP_PATH=/keg/tap
+ARG DOC_APP_PATH=/keg/app
 ARG GIT_APP_URL=https://github.com/simpleviewinc/keg-test-consumer.git
 ARG GIT_APP_BRANCH=master
 # Flag to copy over the taps local folder instead of pulling from git
@@ -8,7 +8,7 @@ ARG KEG_COPY_LOCAL
 # Add a FROM for the tap-base image to we can copy content from it
 ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
 FROM $KEG_BASE_IMAGE as tap-base
-ARG DOC_APP_PATH=/keg/tap
+ARG DOC_APP_PATH=/keg/app
 ENV DOC_APP_PATH=$DOC_APP_PATH
 
 # link repo to provider

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,43 +1,21 @@
-# Allows overwriting where the base image is pulled from
-# Must come before the FROM directive
-ARG KEG_NODE_VERSION
-ARG GIT_STAGE_IMAGE_FROM=node:$KEG_NODE_VERSION
-FROM $GIT_STAGE_IMAGE_FROM as builder
+# Path of the tap within the docker container
+ARG DOC_APP_PATH=/keg/tap
+ARG GIT_APP_URL=https://github.com/simpleviewinc/tap-events-force.git
+ARG GIT_APP_BRANCH=master
+# Flag to copy over the taps local folder instead of pulling from git
+ARG KEG_COPY_LOCAL
 
-WORKDIR /
+# Add a FROM for the tap-base image to we can copy content from it
+ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
+FROM $KEG_BASE_IMAGE as tap-base
 
-# Add npm-run-all globally
-RUN yarn global add npm-run-all
-
-# Path of the app within the docker container
-ARG DOC_APP_PATH=${DOC_APP_PATH:-/keg/app}
-ARG KEG_PROXY_PORT=${KEG_PROXY_PORT:-3000}
-
-# Copy over the app to a temp directory
-COPY . $DOC_APP_PATH
-
-# Install the dependecies with yarn setup, then remove the .npmrc
-RUN cd $DOC_APP_PATH; \
-    yarn install --ignore-engines; \
-    yarn cache clean;
-
-# Install git for the new stage
-RUN apk add --no-cache git bash sudo; \
-    echo fs.inotify.max_user_watches=1048576 | sudo tee -a /etc/sysctl.conf; \
-    sudo sysctl -p; \
-    rm -rf /var/cache/apk/*; \
-    /bin/sed -i '1s|.*|root:x:0:0:root:/root:/bin/bash|g' /etc/passwd
-
-# Add yarn's global bin to PATH
-ENV PATH=$PATH:/usr/local/share/.config/yarn/global/node_modules/.bin
-
-# Expose container ports
-EXPOSE $KEG_PROXY_PORT
+ARG DOC_APP_PATH=/keg/tap
+ENV DOC_APP_PATH=$DOC_APP_PATH
 
 # Set the current directory to tap repo
 WORKDIR $DOC_APP_PATH
 
-SHELL [ "/bin/bash" ]
+EXPOSE $KEG_PROXY_PORT
 
 # Run the start script
 CMD [ "/bin/bash", "container/run.sh" ]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,6 @@
 # Path of the tap within the docker container
 ARG DOC_APP_PATH=/keg/tap
-ARG GIT_APP_URL=https://github.com/simpleviewinc/tap-events-force.git
+ARG GIT_APP_URL=https://github.com/simpleviewinc/keg-test-consumer.git
 ARG GIT_APP_BRANCH=master
 # Flag to copy over the taps local folder instead of pulling from git
 ARG KEG_COPY_LOCAL

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -1,37 +1,17 @@
 version: "3.8"
 services:
-  keg-test-consumer:
-    privileged: true
-    volumes:
-      - ${CLI_PATH}:${DOC_CLI_PATH}
-    build:
-      context: ${KEG_CONTEXT_PATH}
-      dockerfile: ${KEG_DOCKER_FILE}
-      args:
-        - DOC_APP_PATH
-        - KEG_NODE_VERSION
-        - KEG_PROXY_PORT
-        - DOC_CORE_PATH
-        - DOC_COMPONENTS_PATH
-        - DOC_RESOLVER_PATH
-        - DOC_RETHEME_PATH
-        - DOC_EVF_PATH
-        - DOC_JSUTILS_PAT
-        - ENV
-        - NODE_ENV
-    container_name: ${CONTAINER_NAME}
+  consumer:
     environment:
+      - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
-      - KEG_PROXY_PORT
-      - ENV
-      - KEG_EXEC_CMD
-      - KEG_DOCKER_EXEC
-      - KEG_NM_INSTALL
-      - KEG_CONSUMER_BUILD_PATH
       - DOC_CORE_PATH
       - DOC_COMPONENTS_PATH
+      - DOC_JSUTILS_PATH
       - DOC_RESOLVER_PATH
       - DOC_RETHEME_PATH
-      - DOC_JSUTILS_PAT
       - DOC_EVF_PATH
+      - GIT_APP_BRANCH
+      - GIT_APP_URL
+      - KEG_EXEC_CMD
+      - KEG_DOCKER_EXEC
       - NODE_ENV

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.8"
 services:
   consumer:
     environment:
-      - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
       - DOC_CORE_PATH
       - DOC_COMPONENTS_PATH

--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -23,126 +23,103 @@ actions:
   evf:
     install: 
       location: /keg/tap
-      privileged: true
       cmds:
         - yarn install
     build:
       location: /keg/tap
-      privileged: true
       cmds:
         - yarn build
     start:
       location: /keg/tap
-      privileged: true
       detach: true
       cmds:
         - yarn dev
     att:
       location: /keg/tap
-      privileged: true
       cmds:
         - bash
   core:
     install:
       location: /keg/tap/node_modules/keg-core
-      privileged: true
       cmds:
         - yarn install
     att:
       location: /keg/tap/node_modules/keg-core
-      privileged: true
       cmds:
         - bash
   jsutils:
     install:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
-      privileged: true
       cmds:
         - yarn install
     start:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
-      privileged: true
       detach: true
       cmds:
         - yarn dev
     copy:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
-      privileged: true
       cmds:
         - rm -rf /keg/app/node_modules/@keg-hub/jsutils/build
         - cp -R /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils/build /keg/app/node_modules/@keg-hub/jsutils/build
   retheme:
     install:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
-      privileged: true
       cmds:
         - yarn install
     build:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
-      privileged: true
       cmds:
         - yarn build
     start:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
-      privileged: true
       detach: true
       cmds:
         - yarn dev
     run:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
-      privileged: true
       cmds:
         - yarn dev
     att:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
-      privileged: true
       cmds:
         - bash
   components:
     install:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
-      privileged: true
       cmds:
         - yarn install
     build:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
-      privileged: true
       cmds:
         - yarn build
     start:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
-      privileged: true
       detach: true
       cmds:
         - yarn dev
     run:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
-      privileged: true
       cmds:
         - yarn dev
     att:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
-      privileged: true
       cmds:
         - bash
   rga:
     install:
       location: /keg/app/node_modules/@keg-hub/rga4
-      privileged: true
       cmds:
         - yarn install
     build:
       location: /keg/app/node_modules/@keg-hub/rga4
-      privileged: true
       cmds:
         - yarn build
     run:
       location: /keg/app/node_modules/@keg-hub/rga4
-      privileged: true
       cmds:
         - yarn dev
     att:
       location: /keg/app/node_modules/@keg-hub/rga4
-      privileged: true
       cmds:
         - bash

--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -1,5 +1,5 @@
 sync:
-  keg-test-consumer:
+  consumer:
     alpha: "/keg/app"
     beta: "docker://tap/keg/app"
     mode: "one-way-replica"
@@ -30,10 +30,11 @@ actions:
       location: /keg/tap
       privileged: true
       cmds:
-        - yarn roll:dev
+        - yarn build
     start:
       location: /keg/tap
       privileged: true
+      detach: true
       cmds:
         - yarn dev
     att:
@@ -61,6 +62,7 @@ actions:
     start:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
       privileged: true
+      detach: true
       cmds:
         - yarn dev
     copy:

--- a/container/run.sh
+++ b/container/run.sh
@@ -1,54 +1,27 @@
 #!/usr/bin/env
-APP_PATH=/keg/app
-
-# If DOC_APP_PATH env is passed override the default app path
-if [[ "$DOC_APP_PATH" ]]; then
-  APP_PATH="$DOC_APP_PATH"
-fi
-
-# Helper to print a message to the terminal
-keg_message(){
-  echo $"[ KEG-CLI ] $1" >&2
-  return
-}
-
-# Runs yarn install at run time
-# Use when adding extra node_modules to keg-core without rebuilding
-keg_run_app_yarn_setup(){
-
-  # Check if $KEG_NM_INSTALL exist, if it doesn't, then return
-  if [[ -z "$KEG_NM_INSTALL" ]]; then
-    return
-  fi
-
-  # Navigate to the app directory, and run the yarn install here
-  cd $APP_PATH
-
-  keg_message "Running yarn install for keg-test-consumer..."
-  yarn install
-
-}
-
-# Runs a yarn command from the package.json
-keg_run_the_app(){
-
-  cd $APP_PATH
-
-  if [[ -z "$KEG_EXEC_CMD" ]]; then
-    KEG_EXEC_CMD="start"
-  fi
-
-  keg_message "Running command 'yarn $KEG_EXEC_CMD'"
-  yarn $KEG_EXEC_CMD
-}
 
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
 if [[ -z "$KEG_DOCKER_EXEC" ]]; then
   tail -f /dev/null
   exit 0
-else
-  keg_run_app_yarn_setup
-  keg_run_the_app
-fi
 
+else
+
+  # Ensure the DOC_APP_PATH is set
+  if [[ -z "$DOC_APP_PATH" ]]; then
+    DOC_APP_PATH=/keg/app
+  fi
+
+  # cd into the app repo
+  cd $DOC_APP_PATH
+
+  if [[ -z "$KEG_EXEC_CMD" ]]; then
+    KEG_EXEC_CMD="start"
+  fi
+
+  # Start the app instance
+  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
+  yarn $KEG_EXEC_CMD
+
+fi

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,3 +1,5 @@
+start: /bin/bash /keg/keg-cli/containers/tap/run.sh
+
 env:
 
   # --- LOCAL ENV CONTEXT --- #
@@ -9,21 +11,22 @@ env:
 
   # --- KEG-CLI ENV CONTEXT --- #
 
-  # Set the paths to the linked external app
-  # The app should be linked to the keg-cli with `kee`
-  # Example command to link the app => `keg tap link kee`
+  # Docker / Docker Compose paths
   KEG_DOCKER_FILE: "{{ cli.taps.links.consumer }}/container/Dockerfile"
   KEG_VALUES_FILE: "{{ cli.taps.links.consumer }}/container/values.yml"
+
+  # The default docker-compose file path
   KEG_COMPOSE_DEFAULT: "{{ cli.taps.links.consumer }}/container/docker-compose.yml"
 
-  # The KEG_CONTEXT_PATH env should be the location of the external app being run
+  # The KEG_CONTEXT_PATH env should be the location of the tap being run
+  # So it should NOT be set inside the .env file
   KEG_CONTEXT_PATH: "{{ cli.taps.links.consumer }}"
-  KEG_IMAGE_FROM: docker.pkg.github.com/simpleviewinc/keg-packages/keg-test-consumer:develop
+  
+  # Image to use when building consumer
+  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
 
-  # --- GIT ENV CONTEXT --- #
-
-  GIT_RETHEME_URL: "{{ cli.git.orgUrl }}/keg-test-consumer.git"
-
+  # Image to use when running consumer
+  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/consumer:master
 
   # --- DOCKER ENV CONTEXT --- #
 
@@ -48,10 +51,14 @@ env:
   IMAGE: keg-test-consumer
   CONTAINER_NAME: keg-test-consumer
   VERSION: "0.0.1"
+  CHOKIDAR_USEPOLLING: 1
 
   # --- KEG TEST CONSUMER ENVs --- #
   # taps can check this environment variable to determine
   # where to place the build output
   KEG_CONSUMER_BUILD_PATH: /keg/app/node_modules/@keg-hub/tap-evf-sessions
-  KEG_FROM_BASE: false
   KEG_EXEC_CMD: start
+
+  # Git tap url in github
+  GIT_APP_URL: https://github.com/simpleviewinc/keg-test-consumer.git
+  GIT_APP_BRANCH: master

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,5 +1,3 @@
-start: /bin/bash /keg/keg-cli/containers/tap/run.sh
-
 env:
 
   # --- LOCAL ENV CONTEXT --- #
@@ -12,15 +10,15 @@ env:
   # --- KEG-CLI ENV CONTEXT --- #
 
   # Docker / Docker Compose paths
-  KEG_DOCKER_FILE: "{{ cli.taps.links.consumer }}/container/Dockerfile"
-  KEG_VALUES_FILE: "{{ cli.taps.links.consumer }}/container/values.yml"
+  KEG_DOCKER_FILE: "{{ cli.taps.consumer.path }}/container/Dockerfile"
+  KEG_VALUES_FILE: "{{ cli.taps.consumer.path }}/container/values.yml"
 
   # The default docker-compose file path
-  KEG_COMPOSE_DEFAULT: "{{ cli.taps.links.consumer }}/container/docker-compose.yml"
+  KEG_COMPOSE_DEFAULT: "{{ cli.taps.consumer.path }}/container/docker-compose.yml"
 
   # The KEG_CONTEXT_PATH env should be the location of the tap being run
   # So it should NOT be set inside the .env file
-  KEG_CONTEXT_PATH: "{{ cli.taps.links.consumer }}"
+  KEG_CONTEXT_PATH: "{{ cli.taps.consumer.path }}"
   
   # Image to use when building consumer
   KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
@@ -51,7 +49,6 @@ env:
   IMAGE: keg-test-consumer
   CONTAINER_NAME: keg-test-consumer
   VERSION: "0.0.1"
-  CHOKIDAR_USEPOLLING: 1
 
   # --- KEG TEST CONSUMER ENVs --- #
   # taps can check this environment variable to determine

--- a/container/values.yml
+++ b/container/values.yml
@@ -46,8 +46,8 @@ env:
 
   # Image/Container Build information
   # IMAGE and CONTAINER_NAME should be the same
-  IMAGE: keg-test-consumer
-  CONTAINER_NAME: keg-test-consumer
+  IMAGE: consumer
+  CONTAINER_NAME: consumer
   VERSION: "0.0.1"
 
   # --- KEG TEST CONSUMER ENVs --- #

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@keg-hub/tap-evf-sessions": "2.4.1"
+    "@keg-hub/tap-evf-sessions": "2.5.0"
   },
   "devDependencies": {
     "@keg-hub/rga4": "0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
   resolved "https://registry.yarnpkg.com/@keg-hub/rga4/-/rga4-0.0.3.tgz#1debf6369331e0f97b76cde3ba983d2c37278598"
   integrity sha512-7zLyT5EMUB5uhd7h1D9gjBJEntwePCCOxwXE0G0U4FoyN8Xfaie66Ctyq4zy4Wfbht8twARuuWwrmnO/GUMT3Q==
 
-"@keg-hub/tap-evf-sessions@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@keg-hub/tap-evf-sessions/-/tap-evf-sessions-2.4.1.tgz#dedb11eb09beaac8ae297e0a381426dd2ecdc677"
-  integrity sha512-qVRAdxNnMEG0NsmiPeAX5WHtm8XpK4YcGqw+oQGN3TZoEMWOE9UpZdgwWbt+K0Ke7Kdoz+yah55n9aDbuDe3lQ==
+"@keg-hub/tap-evf-sessions@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@keg-hub/tap-evf-sessions/-/tap-evf-sessions-2.5.0.tgz#c38a2fc531199bffed71905f60c8285cf69e4caa"
+  integrity sha512-0+uqfC+7o+gpidROFiWQSxb9gDzFFIpTyCI4qTPWkcSRDlJEVHYq51HhkHSt11069Cy3rncxTZg/1vcxrw/YOg==
   dependencies:
     "@keg-hub/jsutils" "8.1.0"
     prop-types "15.7.2"


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-532)
> Depends on this keg-cli PR: https://github.com/simpleviewinc/keg-cli/pull/31

## Context

* Because of the new `image from updates`, we need to update the contents in the `/containers` to work with the new workflow

## Goal
* to ensure you can still run the same commands when working in a container
* Updating the containers folder to work with the new image workflow

## Updates

* `/containers/*`
   * followed a similar setup from the updated `evf` containers folder

## Testing

### Setup
* Pull this branch locally
* ensure your `keg-cli` is on branch `ZEN-463-push-pull-tasks`
* ensure you don't have any keg consumer images locally

### Test 1
* run `keg consumer start`
   * it should pull from `ghcr.io/simpleviewinc/consumer:master`
* navigate to http://consumer-container-update.local.kegdev.xyz/
   * ensure the app loads

### Test 2
* make changes to your local `tap-events-force` or `keg-components` repo
   * *I added a console log and hard coded a text on  default button*
* open a new terminal tab
* run `keg consumer sync evf:install:start,components:install:start`
   * it should install and sync local evf && keg components
* Ensure the changes are reflected
    * [image](https://user-images.githubusercontent.com/3317835/105891225-9ce32b80-5fcd-11eb-8db7-edaa8bd87f01.png)


