### PR TITLE
Added EVFButton mock

### DIFF
--- a/src/EvfSessions.js
+++ b/src/EvfSessions.js
@@ -1,6 +1,7 @@
 import React, {useState, useMemo, useCallback} from 'react'
 import Sessions from '@keg-hub/tap-evf-sessions'
 import testData from './mocks/testData'
+import { EvfButton } from './mocks/evfButton'
 import { evfModalBuilder } from './mocks/evfModalBuilder'
 import { useRGA4 } from '@keg-hub/rga4'
 
@@ -45,7 +46,8 @@ export const EvfSessions = props => {
     showVersion={true}
     onSessionBookingRequest={bookingRequest}
     onSessionWaitingListRequest={waitingRequest}
-    sessionAgendaProps={testData} 
+    sessionAgendaProps={testData}
+    ButtonComponent={EvfButton}
     ModalComponent={SessionsModal}
   />
 }

--- a/src/mocks/evfButton.js
+++ b/src/mocks/evfButton.js
@@ -1,0 +1,48 @@
+/**
+ * IMPORTANT - should not be imported into the main sessions component export
+ * This is for DEVELOPMENT only
+ * https://docs.google.com/document/d/1oTOhGc1fpG0VhqXTq4ZumceZWoi1ln17wFVxG9SmlDE
+ */
+import React from 'react'
+import { Button } from 'reactstrap'
+
+/**
+ * Maps the internal button type to a default bootstrap button color prop
+ * Only used when developing the session component
+ */
+const typeToColorMap = {
+  selectSession: 'info',
+  modalPrimary: 'primary',
+  modalSecondary: 'secondary',
+}
+
+
+/**
+ * This is a demo button component. The real component gets passed in from the Sessions Component consumer
+ * This is basically just a HOC, but called as a function directly
+ *
+ * It will return a functional component to be passed into the Session Component as a prop
+ *
+ * This allows the EU team to define the button in what ever format is needed, including passing in the props
+ * While at the same time, it allows the session component to define the content of the button
+ */
+export const EvfButton = ({
+  children,
+  disabled,
+  buttonType,
+  className,
+  onClick,
+  ...props
+}) => {
+  return (
+    <Button
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      color={typeToColorMap[buttonType]}
+      data-button-type={buttonType}
+    >
+      { children }
+    </Button>
+  )
+}


### PR DESCRIPTION
**Ticket**: [ZEN-556](https://jira.simpleviewtools.com/browse/ZEN-556)

## Context
* See the [Tech Spec here](https://docs.google.com/document/d/1oTOhGc1fpG0VhqXTq4ZumceZWoi1ln17wFVxG9SmlDE/edit)
* Events Force is stating that they need more customization over the Button within the sessions component
* Based on their explanation, they are having issues with styling it properly
* They would like to follow a process similar to the updates we did with the modal component, as seen in these tickets
  * https://jira.simpleviewtools.com/browse/ZEN-446
  * https://jira.simpleviewtools.com/browse/ZEN-502
* Basically, they would pass us a Button component, and we would add some logic to it, and pass it back to them

## Goal

* Allow the evf-button to work like the Modal component and be passed in externally
* Update all references to the button to use this custom evf-button instead of the current button
* Like the modal component, use the bootstrap button when in a development environment
* It should not load the bootstrap button in the production build
* Clean up the button styles

## Updates
* Updated to pass button to session component
* Created mock Button component to use in example

## Testing

* Run the tests from the [EVF PR](https://github.com/simpleviewinc/tap-events-force/pull/124)






